### PR TITLE
Fixes bug RT-78272: Arbitrary code execution from $ENV

### DIFF
--- a/lib/Package/Stash.pm
+++ b/lib/Package/Stash.pm
@@ -12,7 +12,9 @@ BEGIN {
 
     my $err;
     if ($IMPLEMENTATION) {
-        if (!eval "require Package::Stash::$IMPLEMENTATION; 1") {
+        my $file = "Package::Stash::$IMPLEMENTATION.pm";
+        $file =~ s{::}{/}g;
+        if (!eval 'require($file) ; 1') {
             require Carp;
             Carp::croak("Could not load Package::Stash::$IMPLEMENTATION: $@");
         }

--- a/t/bug-rt-78272.t
+++ b/t/bug-rt-78272.t
@@ -1,0 +1,33 @@
+use strict;
+use warnings;
+use Test::More tests => 1;
+use Test::Exception;
+
+subtest 'Bug RT-78272: Arbitrary code execution from $ENV' => sub {
+
+    # https://rt.cpan.org/Public/Bug/Display.html?id=78272
+    my $e = $ENV{PACKAGE_STASH_IMPLEMENTATION} = "PP; exit 1";
+    throws_ok {
+        require Package::Stash;
+    }
+    qr/^Could not load Package::Stash::$e/,
+      'Arbitrary code in $ENV throws exception';
+
+    throws_ok {
+        delete $INC{'Package/Stash.pm'};
+        require Package::Stash;
+    }
+    qr/^Could not load Package::Stash::$e/,
+      'Sanity check: forcing package reload throws the exception again';
+
+    lives_ok {
+        $ENV{PACKAGE_STASH_IMPLEMENTATION} = "PP";
+        delete $INC{'Package/Stash.pm'};
+        require Package::Stash;
+        new_ok(
+            'Package::Stash' => ['Foo'],
+            'Loaded and able to create instances'
+        );
+    }
+    'Valid $ENV value loads correctly';
+};


### PR DESCRIPTION
https://rt.cpan.org/Public/Bug/Display.html?id=78272

Just copied UNIVERSAL::require's solution to the same problem.
I didn't just use it as to not add any non-test dependency.

I've used Test::Exception on the tests, I hope it is ok.
Please, do let me know if I did something which is not acceptable and I'd be more than happy to provide another patch.
