### PR TITLE
Fixes basic-xs.t

### DIFF
--- a/t/impl-selection/basic-xs.t
+++ b/t/impl-selection/basic-xs.t
@@ -278,7 +278,10 @@ is($foo_stash->get_symbol('@foo'), $ARRAY, '... got the right values for @Foo::f
 
     is_deeply(
         $syms,
-        { zork => *{ $Foo::{zork} }{HASH} },
+        {
+            zork => *{ $Foo::{zork} }{HASH},
+            bare => *{ $Foo::{bare} }{HASH},
+        },
         "got the right ones",
     );
 }


### PR DESCRIPTION
This test is failing for me and it seems it is correctly failing as it adds two hashes to the stash and then checks for only one.
But considering it is like this since November 2011, it could just be that I'm horribly missing something :)

Either way, here goes a patch, in case this is the correct fix.
