### PR TITLE
Fix a spurious warning under taint mode

### DIFF
--- a/lib/Package/Stash/PP.pm
+++ b/lib/Package/Stash/PP.pm
@@ -193,6 +193,7 @@ sub add_symbol {
             local *__ANON__:: = $namespace;
             no strict 'refs';
             no warnings 'void';
+            no warnings 'once';
             *{"__ANON__::$name"};
         }
 

--- a/t/warnings-taint.t
+++ b/t/warnings-taint.t
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl -T
+use strict;
+use warnings;
+use Test::More;
+
+use Package::Stash;
+
+my $warnings;
+BEGIN {
+    $warnings = '';
+    $SIG{__WARN__} = sub { $warnings .= $_[0] };
+}
+
+BEGIN {
+    my $stash = Package::Stash->new('Foo');
+    $stash->get_or_add_symbol('$bar');
+}
+
+is($warnings, '');
+
+done_testing;


### PR DESCRIPTION
Bug-Debian: https://bugs.debian.org/762334

This is currently breaking the CGI-Application-Plugin-AJAXUpload test suite. It's unclear to me why it only happens in taint mode. I've added a copy of t/warnings.t, run under -T, which triggers the same problem.
