### PR TITLE
avoid Perl 5.21.x sprintf warning

### DIFF
--- a/t/addsub.t
+++ b/t/addsub.t
@@ -30,7 +30,7 @@ ok(defined($Foo::{funk}), '... the &funk slot was created successfully');
 is((Foo->funk())[0], 'Foo::funk', '... got the right value from the function');
 
 my $line = (Foo->funk())[1];
-is $DB::sub{'Foo::funk'}, sprintf "%s:%d-%d", __FILE__, $line, $line,
+is $DB::sub{'Foo::funk'}, sprintf( "%s:%d-%d", __FILE__, $line, $line ),
     '... got the right %DB::sub value for funk default args';
 
 $foo_stash->add_symbol(
@@ -40,7 +40,7 @@ $foo_stash->add_symbol(
     last_line_num  => 199
 );
 
-is $DB::sub{'Foo::dunk'}, sprintf "%s:%d-%d", "FileName", 100, 199,
+is $DB::sub{'Foo::dunk'}, sprintf( "%s:%d-%d", "FileName", 100, 199 ),
     '... got the right %DB::sub value for dunk with specified args';
 
 done_testing;


### PR DESCRIPTION
In Perl 5.21 a new warning was introduced for too many arguments for printf/sprintf.
