### PR TITLE
PP: Better declared but undef scalar detection

### DIFF
--- a/lib/Package/Stash/PP.pm
+++ b/lib/Package/Stash/PP.pm
@@ -250,6 +250,14 @@ sub has_symbol {
     if (reftype($entry_ref) eq 'GLOB') {
         if ($type eq 'SCALAR') {
             if (BROKEN_SCALAR_INITIALIZATION) {
+                {
+                    my $package = $self->name;
+
+                    # Turning off warnings does not silence this, so intercept it instead.
+                    local $SIG{__WARN__} = sub {1};
+                    return 1 if eval "package $package; my \$y = ${sigil}${name}; 1";
+                }
+
                 return defined ${ *{$entry_ref}{$type} };
             }
             else {

--- a/t/pp_imported_scalars.t
+++ b/t/pp_imported_scalars.t
@@ -1,0 +1,22 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test::More;
+
+BEGIN { $Package::Stash::IMPLEMENTATION = 'PP' }
+
+use Package::Stash;
+
+{
+    package Foo::Test::Scalar;
+    use vars qw/$xyz/;
+
+    sub xyz { 1 };
+    sub abc { 1 };
+}
+
+my $ps = Package::Stash->new('Foo::Test::Scalar');
+Test::More::ok($ps->has_symbol('$xyz'), "Found imported scalar, even though it is undef.");
+Test::More::ok(!$ps->has_symbol('$abc'), "did not find undeclared scalar");
+
+done_testing;


### PR DESCRIPTION
This still will not find undef scalars defined with 'our'. But it will
find undefined scalars added by 'use vars' or other export tools.

This makes use of the fact that 'strict' will throw an exception when using an undeclared variable. Imported variables count as declared :-)
